### PR TITLE
Add login and register route under AuthHandler

### DIFF
--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -1,0 +1,83 @@
+package handlers
+
+import (
+	"firemarksBackend/models"
+	"net/http"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/labstack/echo"
+	"golang.org/x/crypto/bcrypt"
+)
+
+func AuthMountHandler(base *echo.Group) {
+	base.POST("/login", authUser)
+	base.POST("/register", register)
+}
+
+// GET /links
+func authUser(c echo.Context) error {
+	user := &models.User{}
+	credentials := &models.User{}
+	result := &models.PublicUser{}
+
+	if err := c.Bind(credentials); err != nil {
+		return err
+	}
+	// Find documents
+	if err := models.FindUser(credentials.EMail, user); err != nil {
+		return c.NoContent(http.StatusNotFound)
+	}
+
+	if err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(credentials.Password)); err != nil {
+		return c.NoContent(http.StatusForbidden)
+	}
+
+	token := jwt.New(jwt.SigningMethodHS256)
+
+	result.ID = user.ID
+	result.Name = user.Name
+	result.EMail = user.EMail
+	t, err := token.SignedString([]byte(user.EMail))
+	if err != nil {
+		return err
+	}
+
+	result.Token = t
+
+	return c.JSON(http.StatusOK, result)
+}
+
+// POST /users
+func register(c echo.Context) error {
+	newUser := models.NewUser()
+	result := &models.PublicUser{}
+
+	// Read params from context
+	if err := c.Bind(newUser); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest)
+	}
+
+	// Validate model
+	if isValid, errors := newUser.Validate(); isValid != true {
+		return c.JSON(http.StatusUnprocessableEntity, errors)
+	}
+
+	// Create document
+	if err := models.CreateUser(newUser); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError)
+	}
+
+	result.ID = newUser.ID
+	result.Name = newUser.Name
+	result.EMail = newUser.EMail
+
+	token := jwt.New(jwt.SigningMethodHS256)
+	t, err := token.SignedString([]byte(newUser.EMail))
+	if err != nil {
+		return err
+	}
+
+	result.Token = t
+
+	return c.JSON(http.StatusCreated, result)
+}

--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -14,7 +14,7 @@ func AuthMountHandler(base *echo.Group) {
 	base.POST("/register", register)
 }
 
-// GET /links
+// POST/ on login route
 func authUser(c echo.Context) error {
 	user := &models.User{}
 	credentials := &models.User{}
@@ -23,7 +23,7 @@ func authUser(c echo.Context) error {
 	if err := c.Bind(credentials); err != nil {
 		return err
 	}
-	// Find documents
+	// Find one User by provided E-Mail
 	if err := models.FindUser(credentials.EMail, user); err != nil {
 		return c.NoContent(http.StatusNotFound)
 	}
@@ -47,22 +47,22 @@ func authUser(c echo.Context) error {
 	return c.JSON(http.StatusOK, result)
 }
 
-// POST /users
+// POST/ on register route
 func register(c echo.Context) error {
 	newUser := models.NewUser()
 	result := &models.PublicUser{}
 
-	// Read params from context
+	// Bind the context to fill the user model
 	if err := c.Bind(newUser); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest)
 	}
 
-	// Validate model
+	// Validate User
 	if isValid, errors := newUser.Validate(); isValid != true {
 		return c.JSON(http.StatusUnprocessableEntity, errors)
 	}
 
-	// Create document
+	// Create the new User
 	if err := models.CreateUser(newUser); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError)
 	}

--- a/handlers/users.go
+++ b/handlers/users.go
@@ -10,7 +10,6 @@ import (
 // UsersMountHandler sets the routes for the User resource
 func UsersMountHandler(base *echo.Group) {
 	base.GET("", listUsers)
-	base.POST("", createUser)
 }
 
 // GET /users
@@ -23,26 +22,4 @@ func listUsers(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, results)
-}
-
-// POST /users
-func createUser(c echo.Context) error {
-	result := models.NewUser()
-
-	// Read params from context
-	if err := c.Bind(result); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest)
-	}
-
-	// Validate model
-	if isValid, errors := result.Validate(); isValid != true {
-		return c.JSON(http.StatusUnprocessableEntity, errors)
-	}
-
-	// Create document
-	if err := models.CreateUser(result); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError)
-	}
-
-	return c.JSON(http.StatusCreated, result)
 }

--- a/handlers/users.go
+++ b/handlers/users.go
@@ -16,7 +16,7 @@ func UsersMountHandler(base *echo.Group) {
 func listUsers(c echo.Context) error {
 	results := &[]models.User{}
 
-	// Find documents
+	// Find Users
 	if err := models.QueryUsers(results); err != nil {
 		return c.NoContent(http.StatusNotFound)
 	}

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ func main() {
 	})
 	mount(v1, "/links", handlers.LinksMountHandler)
 	mount(v1, "/users", handlers.UsersMountHandler)
+	mount(v1, "", handlers.AuthMountHandler)
 
 	// Server stuff
 	fmt.Println("\n== Running on http://localhost:3000 ==")

--- a/models/user.go
+++ b/models/user.go
@@ -11,10 +11,17 @@ import (
 // User model
 type User struct {
 	ID        bson.ObjectId `json:"id" bson:"_id,omitempty"`
-	Name      string        `form:"name" json:"name"`
-	EMail     string        `form:"email" json:"email"`
-	Password  string        `form:"password" json:"-"`
+	Name      string        `json:"name"`
+	EMail     string        `json:"email"`
+	Password  string        `form:"password"`
 	CreatedAt time.Time     `json:"created_at,omitempty" bson:"created_at,omitempty"`
+}
+
+type PublicUser struct {
+	ID    bson.ObjectId `json:"id" bson:"_id,omitempty"`
+	Name  string        `json:"name"`
+	EMail string        `json:"email"`
+	Token string        `json:"token"`
 }
 
 // NewUser creates a new User with ID and CreatedAt
@@ -72,6 +79,12 @@ func (u *User) Validate() (bool, []ValidationError) {
 // QueryUsers ...
 func QueryUsers(results *[]User) error {
 	return Users().Find(nil).All(results)
+}
+
+// FindLink ...
+func FindUser(email string, user *User) error {
+	query := bson.M{"email": email}
+	return Users().Find(query).One(user)
 }
 
 // CreateUser ...

--- a/models/user.go
+++ b/models/user.go
@@ -81,7 +81,7 @@ func QueryUsers(results *[]User) error {
 	return Users().Find(nil).All(results)
 }
 
-// FindLink ...
+// Find One User by E-Mail
 func FindUser(email string, user *User) error {
 	query := bson.M{"email": email}
 	return Users().Find(query).One(user)


### PR DESCRIPTION
I just finished the register and login route.

I am creating a PR so we can discuss about things. 
### What's still missing
- [ ] No centralised token-create function
- [ ] Workaround (or legit?) with PublicUser and normal User. Because I don't want to expose all fields and somehow this `json:"-"` is not really working the way I want it to work
- [ ] Check that user cannot exist more than once
- [ ] Set expiration date on token

You probably find more things. 
### How it works:
#### Login:

```
curl -X "POST" "http://localhost:3000/api/v1/login" \
     -H "Content-Type: application/json; charset=utf-8" \
     -d "{\"email\":\"USEREMAIL\",\"password\":\"USERPASSWORD\"}"
```
##### Register:

```
curl -X "POST" "http://localhost:3000/api/v1/register" \
     -H "Content-Type: application/json; charset=utf-8" \
     -d "{\"email\":\"TESTEMAIL\",\"password\":\"TESTPASSWORD\",\"name\":\"USERNAME\"}"
```
### My thougts

Slowly I am getting the Go mindset. For now, almost all the web projects I find in Go are not using echo. Also, I am still looking for a "Go" way of doing things. 
